### PR TITLE
Add GitHub as gem homepage

### DIFF
--- a/grape-reload.gemspec
+++ b/grape-reload.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["AMar4enko"]
   spec.email         = ["amar4enko@gmail.com"]
   spec.summary       = 'Grape autoreload gem'
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/AlexYankee/grape-reload"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")


### PR DESCRIPTION
Currently grape-reload doesn't have a link to Github on RubyGems.org. Since there isn't a homepage for it, I suggest adding the Github repository as the homepage. That way it's easier to navigate between the two sites without having to look up where the repository is.