### PR TITLE
Allow higher runtime dependency versions, preserve Grape API version info

### DIFF
--- a/grape-reload.gemspec
+++ b/grape-reload.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "grape", "~> 0.10.1"
-  spec.add_runtime_dependency "rack", "~> 1.5.2"
+  spec.add_runtime_dependency "grape", ">= 0.10.1"
+  spec.add_runtime_dependency "rack", ">= 1.5.2"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/grape/reload/grape_api.rb
+++ b/lib/grape/reload/grape_api.rb
@@ -60,7 +60,7 @@ module Grape
           @skip_declaration = false
         end
 
-        [:set, :imbue, :mount, :route, :desc, :params, :helpers, :format, :formatter, :parser, :error_formatter, :content_type].each do |method|
+        [:set, :imbue, :mount, :route, :desc, :params, :helpers, :format, :formatter, :parser, :error_formatter, :content_type, :version].each do |method|
           eval <<METHOD
           def #{method}(*args, &block)
             class_declaration << [:#{method},args,block] unless @skip_declaration

--- a/spec/grape/reload/autoreload_interceptor_spec.rb
+++ b/spec/grape/reload/autoreload_interceptor_spec.rb
@@ -10,12 +10,20 @@ describe Grape::Reload::AutoreloadInterceptor do
       end
     end
 
+    versioned_class = Class.new(Grape::API) do
+      version :v1
+      get 'versioned_route' do
+        'versioned route'
+      end
+    end
+
     Class.new(Grape::API) do
       format :txt
       get :test_route do
         'test'
       end
       mount nested_class => '/nested'
+      mount versioned_class
     end
   }
 
@@ -44,5 +52,16 @@ describe Grape::Reload::AutoreloadInterceptor do
       expect(last_response).to succeed
       expect(last_response.body).to eq('nested route')
     end
+
+    it 'preserves the API version' do
+      get '/v1/versioned_route'
+      expect(last_response).to succeed
+      expect(last_response.body).to eq('versioned route')
+      api_class.reinit!
+      get '/v1/versioned_route'
+      expect(last_response).to succeed
+      expect(last_response.body).to eq('versioned route')
+    end
+
   end
 end


### PR DESCRIPTION
1) Currently newer Grape versions like 0.11.0 are blocked, but this version works fine with grape-reload.

2) The version of a Grape API was not preserved during a reload. For example the method bar in

class Foo < Grape::Api
  version 'v1'
  get 'bar' do
  end
end

can be accessed under /v1/bar, but after a reload it is found under /bar.
